### PR TITLE
Fix the test for Audio errors

### DIFF
--- a/src/components/VAudioTrack/VAudioTrack.vue
+++ b/src/components/VAudioTrack/VAudioTrack.vue
@@ -297,7 +297,7 @@ export default defineComponent({
       )
 
       if (
-        route.value.params.id === props.audio.id ||
+        route.value?.params?.id === props.audio.id ||
         mediaStore.getItemById(AUDIO, props.audio.id)
       ) {
         /**

--- a/src/components/VAudioTrack/VWaveform.vue
+++ b/src/components/VAudioTrack/VWaveform.vue
@@ -137,6 +137,7 @@
     <!-- Message overlay -->
     <div
       v-else
+      data-testid="audio-message"
       class="loading absolute inset-0 flex items-center justify-center text-xs font-bold"
     >
       {{ message }}

--- a/test/unit/specs/components/AudioTrack/v-audio-track.spec.js
+++ b/test/unit/specs/components/AudioTrack/v-audio-track.spec.js
@@ -30,7 +30,10 @@ jest.mock('~/composables/use-browser-detection', () => ({
 }))
 
 jest.mock('~/composables/use-i18n', () => ({
-  useI18n: jest.fn(() => mockI18n),
+  useI18n: jest.fn(() => ({
+    t: jest.fn((val) => val),
+    tc: jest.fn((val) => val),
+  })),
 }))
 
 const useVueI18n = (vue) => {
@@ -88,9 +91,6 @@ describe('AudioTrack', () => {
     options = {
       propsData: props,
       stubs,
-      mocks: {
-        $nuxt: { context: { i18n: { t: jest.fn() } } },
-      },
     }
 
     setActivePinia(createPinia())
@@ -121,13 +121,29 @@ describe('AudioTrack', () => {
     expect(element).toHaveAttribute('href', props.audio.creator_url)
   })
 
-  it.skip('on play error displays a message instead of the waveform', async () => {
+  it('on play error displays a message instead of the waveform', async () => {
     options.propsData.audio.url = 'bad.url'
     options.propsData.layout = 'row'
     options.stubs.VPlayPause = false
-    const { debug, getByRole } = render(VAudioTrack, options, configureVue)
+    options.stubs.VWaveform = false
+    options.stubs.VAudioThumbnail = true
+    const pauseStub = jest
+      .spyOn(window.HTMLMediaElement.prototype, 'pause')
+      .mockImplementation(() => undefined)
+
+    const playStub = jest
+      .spyOn(window.HTMLMediaElement.prototype, 'play')
+      .mockImplementation(() => Promise.reject('NotAllowedError'))
+    const { getByRole, getByTestId } = render(
+      VAudioTrack,
+      options,
+      configureVue
+    )
+
     await fireEvent.click(getByRole('button'))
-    debug()
-    // TODO: Fix error when trying to access route params
+    await expect(playStub).toHaveBeenCalledTimes(1)
+    await expect(pauseStub).toHaveBeenCalledTimes(1)
+    await expect(getByTestId('audio-message')).toBeVisible()
+    // It's not possible to get the vm to test that Sentry has been called
   })
 })


### PR DESCRIPTION
This is an addition to the audio error tests that stubs `window.HTMLMediaElement.prototype`.